### PR TITLE
Allow Laravel 13 (`^13.0`)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
-        "laravel/framework": "^9.0|^10.0|^11.0|^12.0",
+        "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0",
+        "laravel/framework": "^9.0|^10.0|^11.0|^12.0|^13.0",
         "predis/predis": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
## What

Add `^13.0` to `laravel/framework` and `illuminate/support` constraints in `composer.json`.

## Why

Used by [gescat-laravel](https://github.com/padosoft/gescat-laravel) on branch `shift-174733` (upgrade Laravel 12 → 13). Without this change, the package blocks composer resolution on consumer projects targeting Laravel 13.

## Compatibility

Additive only — no breaking changes for existing L9-L12 users. The `|^13.0` is appended after the existing range, all prior constraints remain unchanged.

## Patch

See [a2a9b87](https://github.com/luca9692/laravel-super-cache-invalidate/commit/a2a9b87a116fe92ffb1cb3bdd3a7245018fc3c92) — 2 lines changed in `composer.json`.